### PR TITLE
Multiple Inheritance - wrong referred program name (should be Task-340B instead of Task460B)

### DIFF
--- a/level6/Cplusplus-oop.md
+++ b/level6/Cplusplus-oop.md
@@ -758,7 +758,7 @@ Let's look at `Flashy` and we see the ISR has been slightly modified. The `Ticke
 ## Further topics
 
 ### Multiple Inheritance
-C++ allows us to  inherit code from more than one class. You can see an example of this in Task460B
+C++ allows us to  inherit code from more than one class. You can see an example of this in Task-340B
 
 ### Pure Virtual Functions
 Some other languages have "interfaces", which are similar to classes, but contain no code. The nearest equivalent in C++ is "abstract classes". This is a rather an advanced topic, but an example has been provided in Task-342


### PR DESCRIPTION
#14 
Program given as Task460B which is wrong as this does not exist, should be Task-340B, this program name is correct as ends with -Mult_Inheritance.