### PR TITLE
Wrong referenced program name for Task 368

### DIFF
--- a/level6/threads1.md
+++ b/level6/threads1.md
@@ -883,7 +883,7 @@ When you start a thread, it is possible to also pass parameters to the thread fu
 
 | TASK 368 | Thread Parameters |
 | --- | --- |
-| 1. | Make Task-366 the Active Program |
+| 1. | Make Task-368 the Active Program |
 | 2. | Build and run the application |
 | 3. | Study the code carefully. |
 


### PR DESCRIPTION
For: Passing Parameters to Threads 
| TASK 368 | Thread Parameters |
Program referenced as Task-366 and should instead be Task-368.