### PR TITLE
I think TASK-382 Q3 should reference button B only

### DIFF
--- a/level6/thread_abstractions.md
+++ b/level6/thread_abstractions.md
@@ -142,7 +142,7 @@ We then fill this segment of memory with some data and send the address through 
 | 2. | Add some code to the ISR to busy-wait block on buttonA |
 | - | What happens if you hold down buttonA? |
 | 3. | Add some code to the consumer thread to busy-wait block on buttonB |
-| - | What happens if you hold down buttonA? |
+| - | What happens if you hold down buttonB? |
 | 4. | For each interrupt, how many bytes are sent by the message queue to the consumer thread? |
 | 5. |  The objects use shared memory without any locks. Why is this code thread safe? |
 


### PR DESCRIPTION
I think TASK-382 Q3 should reference button B for question as well as task instead of A as task is for button B unlike task and question for Q2.